### PR TITLE
Feature: Show Booked on Rockets Page

### DIFF
--- a/src/Components/Rocket.js
+++ b/src/Components/Rocket.js
@@ -4,7 +4,6 @@ import { bookRocket, cancelRocket } from "../Redux/rockets/rocket";
 
 function Rocket({ rocket }) {
   const dispatch = useDispatch();
-  console.log(rocket.reserved);
   const bookIURocket = () => {
     dispatch(bookRocket(rocket.id));
   }
@@ -17,6 +16,7 @@ function Rocket({ rocket }) {
       <div className="rocket-description">
         <h2>{rocket.rocket_name}</h2>
         <p>
+        {rocket.reserved && (<span className="success-rocket">Reserved</span>)}
         {rocket.description}
         </p>
         <div>

--- a/src/index.css
+++ b/src/index.css
@@ -30,3 +30,7 @@
 .actived-navlink {
   text-decoration: underline;
 }
+
+.success-rocket {
+  background-color: green;
+}


### PR DESCRIPTION
In this update : 

- Rockets that have already been reserved should show a "Reserved" badge and "Cancel reservation" button instead of the default "Reserve rocket" (as per design)